### PR TITLE
Don't fail if filename doesn't have a version number

### DIFF
--- a/src/directory_entry/isofile.rs
+++ b/src/directory_entry/isofile.rs
@@ -37,12 +37,16 @@ impl<T: ISO9660Reader> ISOFile<T> {
         file: FileRef<T>,
     ) -> Result<ISOFile<T>> {
         // Files (not directories) in ISO 9660 have a version number, which is
-        // provided at the end of the identifier, seperated by ';'
-        let error = ISOError::InvalidFs("File indentifier missing ';'");
-        let idx = identifier.rfind(';').ok_or(error)?;
-
-        let version = u16::from_str(&identifier[idx + 1..])?;
-        identifier.truncate(idx);
+        // provided at the end of the identifier, seperated by ';'.
+        // If not, assume 1.
+        let version = match identifier.rfind(';') {
+            Some(idx) => {
+                let version = u16::from_str(&identifier[idx + 1..])?;
+                identifier.truncate(idx);
+                version
+            },
+            None => 1
+        };
 
         // Files without an extension have a '.' at the end
         if identifier.ends_with('.') {


### PR DESCRIPTION
Hello, thank you for your work on this crate.

I used it to read an old ISO of Windows XP and it failed because filenames doesn't have a version number at the end. Maybe microsoft only implemented a subset of the standard(?).
Anyway here is a patch that assume '1' as version number if it's not present instead of returning an error. (I could read the ISO successfully with this).

Thanks again