### PR TITLE
Add try_into_inner() for ISO9660 and FileRef

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum ISOError {
     ParseInt(ParseIntError),
     ReadSize(usize, usize),
     Nom(nom::error::ErrorKind),
+    IntoInner(&'static str),
 }
 
 impl Display for ISOError {
@@ -28,6 +29,7 @@ impl Display for ISOError {
                 size, size_read
             ),
             ISOError::Nom(ref err) => write!(f, "Parse error: {:?}", err),
+            ISOError::IntoInner(msg) => write!(f, "Into inner error: {}", msg),
         }
     }
 }

--- a/src/fileref.rs
+++ b/src/fileref.rs
@@ -62,4 +62,14 @@ impl<T: ISO9660Reader> FileRef<T> {
     pub fn read_at(&self, buf: &mut [u8], lba: u64) -> Result<usize> {
         (*self.0).borrow_mut().read_at(buf, lba)
     }
+
+    /// Try returning inner value (will work if Rc has exactly one strong ref)
+    /// Returns Self on error
+    pub fn try_into_inner(self) -> std::result::Result<T, Self> {
+        match Rc::<RefCell<T>>::try_unwrap(self.0) {
+            Ok(refcell) => Ok(refcell.into_inner()),
+            Err(rcrefcell) => Err(FileRef(rcrefcell))
+        }
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,16 @@ impl<T: ISO9660Reader> ISO9660<T> {
         2048 // XXX
     }
 
+    /// Returns inner reader, consuming self.
+    /// This will fail if references to T are still used (e.g. ISODirectory<T> or ISOFile<T>).
+    pub fn try_into_inner(self) -> Result<T> {
+        // Drop root first since it owns a _file ref
+        drop(self.root);
+        self._file.try_into_inner().map_err(|_|
+            ISOError::IntoInner("Inner reader still referenced")
+        )
+    }
+
     primary_prop_str!(volume_set_identifier);
     primary_prop_str!(publisher_identifier);
     primary_prop_str!(data_preparer_identifier);


### PR DESCRIPTION
Hello !

It would be nice to get ownership of the inner reader back when we're done. Not sure this is the best approach, FileRef makes this tricky but it works for me.