### PR TITLE
Joliet (UCS-2/UTF-16) support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/ids1024/iso9660-rs"
 time = "0.3"
 bitflags = "2.0"
 nom = "7.1"
+encoding_rs = "0.8.32"
 
 [dev-dependencies]
 md5 = "0.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use std::{io, str};
 pub enum ISOError {
     Io(io::Error),
     Utf8(str::Utf8Error),
+    Utf16,
     InvalidFs(&'static str),
     ParseInt(ParseIntError),
     ReadSize(usize, usize),
@@ -20,6 +21,7 @@ impl Display for ISOError {
         match *self {
             ISOError::Io(ref err) => write!(f, "IO error: {}", err),
             ISOError::Utf8(ref err) => write!(f, "UTF8 error: {}", err),
+            ISOError::Utf16 => write!(f, "UTF-16 / UCS-2 conversion error"),
             ISOError::InvalidFs(msg) => write!(f, "Invalid ISO9660: {}", msg),
             ISOError::ParseInt(ref err) => write!(f, "Int parse error: {}", err),
             ISOError::ReadSize(size, size_read) => write!(

--- a/src/parse/directory_entry.rs
+++ b/src/parse/directory_entry.rs
@@ -4,7 +4,8 @@ use time::OffsetDateTime;
 
 use super::both_endian::{both_endian16, both_endian32};
 use super::date_time::date_time;
-use crate::Result;
+use super::volume_descriptor::CharacterEncoding;
+use crate::{Result, ISOError};
 use nom::combinator::{map, map_res};
 use nom::multi::length_data;
 use nom::number::complete::le_u8;
@@ -35,15 +36,16 @@ pub struct DirectoryEntryHeader {
     pub file_unit_size: u8,
     pub interleave_gap_size: u8,
     pub volume_sequence_number: u16,
+    pub character_encoding: CharacterEncoding,
 }
 
 impl DirectoryEntryHeader {
-    pub fn parse(input: &[u8]) -> Result<(DirectoryEntryHeader, String)> {
-        Ok(directory_entry(input)?.1)
+    pub fn parse(input: &[u8], character_encoding: CharacterEncoding) -> Result<(DirectoryEntryHeader, String)> {
+        Ok(directory_entry(input, character_encoding)?.1)
     }
 }
 
-pub fn directory_entry(i: &[u8]) -> IResult<&[u8], (DirectoryEntryHeader, String)> {
+pub fn directory_entry(i: &[u8], character_encoding: CharacterEncoding) -> IResult<&[u8], (DirectoryEntryHeader, String)> {
     let (i, length) = le_u8(i)?;
     let (i, extended_attribute_record_length) = le_u8(i)?;
     let (i, extent_loc) = both_endian32(i)?;
@@ -53,7 +55,34 @@ pub fn directory_entry(i: &[u8]) -> IResult<&[u8], (DirectoryEntryHeader, String
     let (i, file_unit_size) = le_u8(i)?;
     let (i, interleave_gap_size) = le_u8(i)?;
     let (i, volume_sequence_number) = both_endian16(i)?;
-    let (i, identifier) = map(map_res(length_data(le_u8), str::from_utf8), str::to_string)(i)?;
+
+    let (i, identifier) = match character_encoding {
+        CharacterEncoding::Iso9660 => map(map_res(length_data(le_u8), str::from_utf8), str::to_string)(i)?,
+        CharacterEncoding::Ucs2Level1 |
+        CharacterEncoding::Ucs2Level2 |
+        CharacterEncoding::Ucs2Level3 => map_res(
+            length_data(le_u8),
+            |bytes : &[u8]| {
+                // From https://www.unicode.org/faq/utf_bom.html#utf16-11
+                // UCS-2 does not describe a data format distinct from UTF-16, because both use
+                // exactly the same 16-bit code unit representations. However, UCS-2 does not
+                // interpret surrogate code points, and thus cannot be used to conformantly
+                // represent supplementary characters.
+                if bytes == &[0] {
+                    Ok("\u{0}".into())
+                } else if bytes == &[1] {
+                    Ok("\u{1}".into())
+                } else {
+                    let (cow, _encoding_used, had_errors) = encoding_rs::UTF_16BE.decode(&bytes);
+                    if had_errors {
+                        Err(ISOError::Utf16)
+                    } else {
+                        Ok(cow.to_string())
+                    }
+                }
+            })(i)?,
+    };
+
     // After the file identifier, ISO 9660 allows addition space for
     // system use. Ignore that for now.
 
@@ -70,6 +99,7 @@ pub fn directory_entry(i: &[u8]) -> IResult<&[u8], (DirectoryEntryHeader, String
                 file_unit_size,
                 interleave_gap_size,
                 volume_sequence_number,
+                character_encoding,
             },
             identifier,
         ),

--- a/src/parse/volume_descriptor.rs
+++ b/src/parse/volume_descriptor.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 
+use nom::branch::alt;
 use nom::bytes::complete::{tag, take};
-use nom::combinator::{map, map_res};
+use nom::combinator::{map, map_res, value};
 use nom::number::complete::*;
 use nom::sequence::tuple;
 use nom::IResult;
@@ -11,41 +12,92 @@ use time::OffsetDateTime;
 use super::both_endian::{both_endian16, both_endian32};
 use super::date_time::date_time_ascii;
 use super::directory_entry::{directory_entry, DirectoryEntryHeader};
-use crate::ISOError;
+use crate::Result;
+
+#[derive(Clone, Debug)]
+pub struct VolumeDescriptorTable {
+    pub system_identifier: String,
+    pub volume_identifier: String,
+    pub character_encoding: CharacterEncoding,
+    pub volume_space_size: u32,
+    pub volume_set_size: u16,
+    pub volume_sequence_number: u16,
+    pub logical_block_size: u16,
+
+    pub path_table_size: u32,
+    pub path_table_loc: u32,
+    pub optional_path_table_loc: u32,
+
+    pub root_directory_entry: DirectoryEntryHeader,
+    pub root_directory_entry_identifier: String,
+
+    pub volume_set_identifier: String,
+    pub publisher_identifier: String,
+    pub data_preparer_identifier: String,
+    pub application_identifier: String,
+    pub copyright_file_identifier: String,
+    pub abstract_file_identifier: String,
+    pub bibliographic_file_identifier: String,
+
+    pub creation_time: OffsetDateTime,
+    pub modification_time: OffsetDateTime,
+    pub expiration_time: OffsetDateTime,
+    pub effective_time: OffsetDateTime,
+
+    pub file_structure_version: u8,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum CharacterEncoding {
+    Iso9660,
+    Ucs2Level1,
+    Ucs2Level2,
+    Ucs2Level3,
+}
+
+impl CharacterEncoding {
+    pub fn parse(bytes: &[u8]) -> IResult<&[u8], Self> {
+        // The field is 32 bytes long, and per §8.5.6 ECMA says there can be multiple
+        // encodings listed.  But. Really.  For now let's just check for the standard
+        // ISO 9660 encoding or UCS-2.
+
+        // Per ECMA 35 / ISO 2022 §13.2.2:
+        // I byte 0x25 (02/05) = Designate Other Coding System
+        //
+        // Per ECMA 35 / ISO 2022 §15.4.2:
+        // DOCS with I byte 0x2F (02/15) shall mean it's not really DOCS and we should
+        // use the registry as a reference.
+        //
+        // ISO Registry shows:
+        // #162 UCS-2 Level 1 F byte is 0x40 (04/00)
+        // #175 UCS-2 Level 2 F byte is 0x43 (04/03)
+        // #175 UCS-2 Level 3 F byte is 0x45 (04/05)
+        let orig_len = bytes.len();
+
+        let (bytes, encoding) = alt((
+            value(CharacterEncoding::Ucs2Level1, tag(&[0x25, 0x2F, 0x40])),
+            value(CharacterEncoding::Ucs2Level2, tag(&[0x25, 0x2F, 0x43])),
+            value(CharacterEncoding::Ucs2Level3, tag(&[0x25, 0x2F, 0x45])),
+            value(CharacterEncoding::Iso9660, tag(&[0_u8; 32])),
+        ))(bytes)?;
+
+        let bytes = match orig_len - bytes.len() {
+            len if len < 32 => {
+                take(32 - len)(bytes)?.0
+            },
+            _ => bytes
+        };
+
+        Ok((bytes, encoding))
+    }
+}
+
 
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) enum VolumeDescriptor {
-    Primary {
-        system_identifier: String,
-        volume_identifier: String,
-        volume_space_size: u32,
-        volume_set_size: u16,
-        volume_sequence_number: u16,
-        logical_block_size: u16,
-
-        path_table_size: u32,
-        path_table_loc: u32,
-        optional_path_table_loc: u32,
-
-        root_directory_entry: DirectoryEntryHeader,
-        root_directory_entry_identifier: String,
-
-        volume_set_identifier: String,
-        publisher_identifier: String,
-        data_preparer_identifier: String,
-        application_identifier: String,
-        copyright_file_identifier: String,
-        abstract_file_identifier: String,
-        bibliographic_file_identifier: String,
-
-        creation_time: OffsetDateTime,
-        modification_time: OffsetDateTime,
-        expiration_time: OffsetDateTime,
-        effective_time: OffsetDateTime,
-
-        file_structure_version: u8,
-    },
+    Primary(VolumeDescriptorTable),
+    Supplementary(VolumeDescriptorTable),
     BootRecord {
         boot_system_identifier: String,
         boot_identifier: String,
@@ -55,7 +107,7 @@ pub(crate) enum VolumeDescriptor {
 }
 
 impl VolumeDescriptor {
-    pub fn parse(bytes: &[u8]) -> Result<Option<VolumeDescriptor>, ISOError> {
+    pub fn parse(bytes: &[u8]) -> Result<Option<VolumeDescriptor>> {
         Ok(volume_descriptor(bytes)?.1)
     }
 }
@@ -91,20 +143,20 @@ fn volume_descriptor(i: &[u8]) -> IResult<&[u8], Option<VolumeDescriptor>> {
     match type_code {
         0 => map(boot_record, Some)(i),
         1 => map(primary_descriptor, Some)(i),
-        //2 => map(supplementary_volume_descriptor, Some)(i),
+        2 => map(supplementary_descriptor, Some)(i),
         //3 => map!(volume_partition_descriptor, Some)(i),
         255 => Ok((i, Some(VolumeDescriptor::VolumeDescriptorSetTerminator))),
         _ => Ok((i, None)),
     }
 }
 
-fn primary_descriptor(i: &[u8]) -> IResult<&[u8], VolumeDescriptor> {
+fn descriptor_table(i: &[u8]) -> IResult<&[u8], VolumeDescriptorTable> {
     let (i, _) = take(1usize)(i)?; // padding
     let (i, system_identifier) = take_string_trim(32usize)(i)?;
     let (i, volume_identifier) = take_string_trim(32usize)(i)?;
     let (i, _) = take(8usize)(i)?; // padding
     let (i, volume_space_size) = both_endian32(i)?;
-    let (i, _) = take(32usize)(i)?; // padding
+    let (i, character_encoding) = CharacterEncoding::parse(i)?;
     let (i, volume_set_size) = both_endian16(i)?;
     let (i, volume_sequence_number) = both_endian16(i)?;
     let (i, logical_block_size) = both_endian16(i)?;
@@ -115,7 +167,7 @@ fn primary_descriptor(i: &[u8]) -> IResult<&[u8], VolumeDescriptor> {
     let (i, _) = take(4usize)(i)?; // path_table_loc_be
     let (i, _) = take(4usize)(i)?; // optional_path_table_loc_be
 
-    let (i, root_directory_entry) = directory_entry(i)?;
+    let (i, root_directory_entry) = directory_entry(i, character_encoding)?;
 
     let (i, volume_set_identifier) = take_string_trim(128)(i)?;
     let (i, publisher_identifier) = take_string_trim(128)(i)?;
@@ -134,9 +186,10 @@ fn primary_descriptor(i: &[u8]) -> IResult<&[u8], VolumeDescriptor> {
 
     Ok((
         i,
-        VolumeDescriptor::Primary {
+        VolumeDescriptorTable {
             system_identifier,
             volume_identifier,
+            character_encoding,
             volume_space_size,
             volume_set_size,
             volume_sequence_number,
@@ -165,4 +218,12 @@ fn primary_descriptor(i: &[u8]) -> IResult<&[u8], VolumeDescriptor> {
             file_structure_version,
         },
     ))
+}
+
+fn supplementary_descriptor<'a>(i: &'a [u8]) -> IResult<&'a [u8], VolumeDescriptor> {
+    map(descriptor_table, VolumeDescriptor::Supplementary)(i)
+}
+
+ fn primary_descriptor(i: &[u8]) -> IResult<&[u8], VolumeDescriptor> {
+    map(descriptor_table, VolumeDescriptor::Primary)(i)
 }


### PR DESCRIPTION
Microsoft's Joliet extensions specify use of a Supplementary Volume Descriptor with big-endian UCS-2 encoding of filenames.  The strategy here is to look at whatever SVDs may be present, and if they specify UCS-2 encoding use them for filename resolution.